### PR TITLE
Fix: Fix the content alignment on the case studies detail page

### DIFF
--- a/app/(case-studies)/case-studies/ctoaas-media/[lang]/page.tsx
+++ b/app/(case-studies)/case-studies/ctoaas-media/[lang]/page.tsx
@@ -140,47 +140,41 @@ function Home({ lang }: { lang: SupportedLanguage }) {
         </div>
 
         {/* CI/CD Transformation  */}
-        <div className="text-hyperjump-black text-left">
+        <div className="text-hyperjump-black mt-5 text-left">
           <h3 className="mb-2 text-lg font-semibold capitalize md:text-[22px]">
             {caseStudyCtoaasMediaCiCdTitle(lang)}
           </h3>
           <ul
-            className="list-disc pl-5"
+            className="list-outside list-disc space-y-2 pl-5 text-lg"
             dangerouslySetInnerHTML={{
               __html: [
                 caseStudyCtoaasMediaCiCd1,
                 caseStudyCtoaasMediaCiCd2,
                 caseStudyCtoaasMediaCiCd3
               ]
-                .map(
-                  (point, index) =>
-                    `<li key=${index} className="mb-2 text-lg">${point(lang)}</li>`
-                )
+                .map((point) => `<li>${point(lang)}</li>`)
                 .join("")
             }}
           />
         </div>
 
         {/* Quality Assurance Reinforcement  */}
-        <div className="text-hyperjump-black text-left">
+        <div className="text-hyperjump-black mt-5 text-left">
           <h3 className="mb-2 text-lg font-semibold capitalize md:text-[22px]">
             {caseStudyCtoaasMediaQaTitle(lang)}
           </h3>
           <ul
-            className="list-disc pl-5"
+            className="list-outside list-disc space-y-2 pl-5 text-lg"
             dangerouslySetInnerHTML={{
               __html: [caseStudyCtoaasMediaQa1, caseStudyCtoaasMediaQa2]
-                .map(
-                  (point, index) =>
-                    `<li key=${index} className="mb-2 text-lg">${point(lang)}</li>`
-                )
+                .map((point) => `<li>${point(lang)}</li>`)
                 .join("")
             }}
           />
         </div>
 
         {/* KPI-Driven Growth  */}
-        <div className="text-hyperjump-black text-left">
+        <div className="text-hyperjump-black mt-5 text-left">
           <h3 className="mb-2 text-lg font-semibold capitalize md:text-[22px]">
             {caseStudyCtoaasMediaKpiTitle(lang)}
           </h3>
@@ -202,28 +196,25 @@ function Home({ lang }: { lang: SupportedLanguage }) {
         </div>
 
         {/* Centralized Feedback Handling  */}
-        <div className="text-hyperjump-black text-left">
+        <div className="text-hyperjump-black mt-5 text-left">
           <h3 className="mb-2 text-lg font-semibold capitalize md:text-[22px]">
             {caseStudyCtoaasMediaCentralizedTitle(lang)}
           </h3>
           <ul
-            className="list-disc pl-5"
+            className="list-outside list-disc space-y-2 pl-5 text-lg"
             dangerouslySetInnerHTML={{
               __html: [
                 caseStudyCtoaasMediaCentralized1,
                 caseStudyCtoaasMediaCentralized2
               ]
-                .map(
-                  (point, index) =>
-                    `<li key=${index} className="mb-2 text-lg">${point(lang)}</li>`
-                )
+                .map((point) => `<li>${point(lang)}</li>`)
                 .join("")
             }}
           />
         </div>
 
         {/* Key Learnings */}
-        <div className="text-hyperjump-black py-4 text-left">
+        <div className="text-hyperjump-black py-5 text-left">
           <h3 className="mb-2 text-2xl font-semibold capitalize md:text-[28px]">
             {caseStudyCtoaasMediaKeyLearningsTitle(lang)}
           </h3>

--- a/app/(case-studies)/case-studies/erp-fisheries/[lang]/page.tsx
+++ b/app/(case-studies)/case-studies/erp-fisheries/[lang]/page.tsx
@@ -102,7 +102,7 @@ function Home({ lang }: { lang: SupportedLanguage }) {
         </div>
 
         {/* Our Approach */}
-        <div className="text-hyperjump-black pt-4 text-left">
+        <div className="text-hyperjump-black pt-5 text-left">
           <h3 className="mb-2 text-2xl font-semibold capitalize md:text-[28px]">
             {caseStudyErpFisheriesApproachTitle(lang)}
           </h3>
@@ -133,7 +133,7 @@ function Home({ lang }: { lang: SupportedLanguage }) {
         </div>
 
         {/* From Zero to Launch */}
-        <div className="text-hyperjump-black text-left">
+        <div className="text-hyperjump-black mt-5 text-left">
           <h3 className="mb-2 text-lg font-semibold capitalize md:text-[22px]">
             {caseStudyErpFisheriesLaunchTitle(lang)}
           </h3>
@@ -154,7 +154,7 @@ function Home({ lang }: { lang: SupportedLanguage }) {
         </div>
 
         {/* Engineering Maturity */}
-        <div className="text-hyperjump-black text-left">
+        <div className="text-hyperjump-black mt-5 text-left">
           <h3 className="mb-2 text-lg font-semibold capitalize md:text-[22px]">
             {caseStudyErpFisheriesEngineeringTitle(lang)}
           </h3>
@@ -176,7 +176,7 @@ function Home({ lang }: { lang: SupportedLanguage }) {
         </div>
 
         {/* Full-System Rollouts */}
-        <div className="text-hyperjump-black text-left">
+        <div className="text-hyperjump-black mt-5 text-left">
           <h3 className="mb-2 text-lg font-semibold capitalize md:text-[22px]">
             {caseStudyErpFisheriesFullSystemRolloutsTitle(lang)}
           </h3>

--- a/app/components/grid-items.tsx
+++ b/app/components/grid-items.tsx
@@ -240,7 +240,7 @@ export function GridItems({
               {category && (
                 <p
                   className={cn(
-                    "mb-2 w-28 rounded-3xl px-2 py-1.5 text-center text-sm font-medium",
+                    "mb-2 w-36 rounded-3xl px-2 py-1.5 text-center text-sm font-medium",
                     categoryClassName
                   )}>
                   {category}

--- a/locales/en/case-study.json
+++ b/locales/en/case-study.json
@@ -10,9 +10,9 @@
   },
   "explore": "Explore Our Case Studies",
   "button": "Read Case Study",
-  "category": "Case Studies",
+  "category": "CTO as a Service",
   "erp_fisheries": {
-    "title": "Transforming a Fisheries Tech Team into a Scalable Product Engine: CTO as a Service",
+    "title": "Transforming a Fisheries Tech Team into a Scalable Product Engine",
     "text": "Empowering a mission-driven startup to digitize Indonesia’s fisheries supply chain—coast to customer.",
     "desc": "A junior but passionate tech team. Zero products in production. High impact at stake. We embedded deeply with their team to introduce structure, build confidence, and ship a functional MVP within 3 months. Through rigorous agile practices and full-system rollouts, we helped evolve a fragile tech org into a reliable product engine.",
     "overview": {
@@ -71,7 +71,7 @@
     }
   },
   "ctoaas_media": {
-    "title": "Elevating a Media-Tech Engineering Team from Feature Factory to Innovation Powerhouse: CTO as a Service",
+    "title": "Elevating a Media-Tech Engineering Team from Feature Factory to Innovation Powerhouse",
     "text": "Helping a leading digital media platform shift from reactive delivery to strategic innovation.",
     "desc": "When rapid growth outpaced engineering maturity, this team needed more than features—they needed transformation. We restructured their agile practices, automated DevOps, established measurable KPIs, and helped them move from task execution to true product ownership and experimentation.",
     "overview": {

--- a/locales/en/case-study.json
+++ b/locales/en/case-study.json
@@ -12,7 +12,7 @@
   "button": "Read Case Study",
   "category": "Case Studies",
   "erp_fisheries": {
-    "title": "Transforming a Fisheries Tech Team into a Scalable Product Engine",
+    "title": "Transforming a Fisheries Tech Team into a Scalable Product Engine: CTO as a Service",
     "text": "Empowering a mission-driven startup to digitize Indonesia’s fisheries supply chain—coast to customer.",
     "desc": "A junior but passionate tech team. Zero products in production. High impact at stake. We embedded deeply with their team to introduce structure, build confidence, and ship a functional MVP within 3 months. Through rigorous agile practices and full-system rollouts, we helped evolve a fragile tech org into a reliable product engine.",
     "overview": {
@@ -71,7 +71,7 @@
     }
   },
   "ctoaas_media": {
-    "title": "Elevating a Media-Tech Engineering Team from Feature Factory to Innovation Powerhouse",
+    "title": "Elevating a Media-Tech Engineering Team from Feature Factory to Innovation Powerhouse: CTO as a Service",
     "text": "Helping a leading digital media platform shift from reactive delivery to strategic innovation.",
     "desc": "When rapid growth outpaced engineering maturity, this team needed more than features—they needed transformation. We restructured their agile practices, automated DevOps, established measurable KPIs, and helped them move from task execution to true product ownership and experimentation.",
     "overview": {

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -42,13 +42,13 @@
     "heading": "Case Studies",
     "desc": "Discover how we successfully transform challenges into opportunities with real-world solutions that drive lasting impact and business growth.",
     "button": "Read Case Study",
-    "0_title": "Transforming a Fisheries Tech Team into a Scalable Product Engine: CTO as a Service",
+    "0_title": "Transforming a Fisheries Tech Team into a Scalable Product Engine",
     "0_text": "A junior but passionate tech team. Zero products in production. High impact at stake. We embedded deeply with their team to introduce structure, build confidence, and ship a functional MVP within 3 months. Through rigorous agile practices and full-system rollouts, we helped evolve a fragile tech org into a reliable product engine.",
-    "0_category": "Case Studies",
+    "0_category": "CTO as a Service",
 
-    "1_title": "Elevating a Media-Tech Engineering Team from Feature Factory to Innovation Powerhouse: CTO as a Service",
+    "1_title": "Elevating a Media-Tech Engineering Team from Feature Factory to Innovation Powerhouse",
     "1_text": "When rapid growth outpaced engineering maturity, this team needed more than features—they needed transformation. We restructured their agile practices, automated DevOps, established measurable KPIs, and helped them move from task execution to true product ownership and experimentation.",
-    "1_category": "Case Studies"
+    "1_category": "CTO as a Service"
   },
   "project": {
     "heading": "Open Source Product",

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -42,11 +42,11 @@
     "heading": "Case Studies",
     "desc": "Discover how we successfully transform challenges into opportunities with real-world solutions that drive lasting impact and business growth.",
     "button": "Read Case Study",
-    "0_title": "Transforming a Fisheries Tech Team into a Scalable Product Engine",
+    "0_title": "Transforming a Fisheries Tech Team into a Scalable Product Engine: CTO as a Service",
     "0_text": "A junior but passionate tech team. Zero products in production. High impact at stake. We embedded deeply with their team to introduce structure, build confidence, and ship a functional MVP within 3 months. Through rigorous agile practices and full-system rollouts, we helped evolve a fragile tech org into a reliable product engine.",
     "0_category": "Case Studies",
 
-    "1_title": "Elevating a Media-Tech Engineering Team from Feature Factory to Innovation Powerhouse",
+    "1_title": "Elevating a Media-Tech Engineering Team from Feature Factory to Innovation Powerhouse: CTO as a Service",
     "1_text": "When rapid growth outpaced engineering maturity, this team needed more than features—they needed transformation. We restructured their agile practices, automated DevOps, established measurable KPIs, and helped them move from task execution to true product ownership and experimentation.",
     "1_category": "Case Studies"
   },

--- a/locales/id/case-study.json
+++ b/locales/id/case-study.json
@@ -10,9 +10,9 @@
   },
   "explore": "Jelajahi Studi Kasus Kami",
   "button": "Baca Studi Kasus",
-  "category": "Studi Kasus",
+  "category": "CTO as a Service",
   "erp_fisheries": {
-    "title": "Mengubah Tim Teknologi Perikanan Menjadi Mesin Produk yang Skalabel: CTO as a Service",
+    "title": "Mengubah Tim Teknologi Perikanan Menjadi Mesin Produk yang Skalabel",
     "text": "Mendukung startup berbasis misi dalam mendigitalkan rantai pasok perikanan Indonesia—dari pesisir ke pelanggan.",
     "desc": "Tim teknologi yang masih junior namun penuh semangat. Tidak ada produk yang berjalan. Taruhan dampak besar. Kami terjun langsung mendampingi tim mereka untuk membangun struktur, meningkatkan kepercayaan diri, dan meluncurkan MVP yang fungsional dalam 3 bulan. Lewat praktik agile yang ketat dan peluncuran sistem penuh, kami bantu mengubah organisasi teknologi yang rapuh menjadi mesin produk yang andal.",
     "overview": {
@@ -71,7 +71,7 @@
     }
   },
   "ctoaas_media": {
-    "title": "Meningkatkan Tim Engineering Media-Tech dari Feature Factory ke Pusat Inovasi: CTO as a Service",
+    "title": "Meningkatkan Tim Engineering Media-Tech dari Feature Factory ke Pusat Inovasi",
     "text": "Membantu platform media digital terkemuka beralih dari sekadar eksekusi ke inovasi strategis.",
     "desc": "Ketika pertumbuhan cepat melampaui kematangan engineering, tim ini butuh lebih dari sekadar fitur—mereka butuh transformasi. Kami restrukturisasi praktik agile mereka, otomatisasi DevOps, tetapkan KPI terukur, dan bantu mereka beralih dari eksekutor tugas ke pemilik produk sejati yang inovatif.",
     "overview": {

--- a/locales/id/case-study.json
+++ b/locales/id/case-study.json
@@ -12,7 +12,7 @@
   "button": "Baca Studi Kasus",
   "category": "Studi Kasus",
   "erp_fisheries": {
-    "title": "Mengubah Tim Teknologi Perikanan Menjadi Mesin Produk yang Skalabel",
+    "title": "Mengubah Tim Teknologi Perikanan Menjadi Mesin Produk yang Skalabel: CTO as a Service",
     "text": "Mendukung startup berbasis misi dalam mendigitalkan rantai pasok perikanan Indonesia—dari pesisir ke pelanggan.",
     "desc": "Tim teknologi yang masih junior namun penuh semangat. Tidak ada produk yang berjalan. Taruhan dampak besar. Kami terjun langsung mendampingi tim mereka untuk membangun struktur, meningkatkan kepercayaan diri, dan meluncurkan MVP yang fungsional dalam 3 bulan. Lewat praktik agile yang ketat dan peluncuran sistem penuh, kami bantu mengubah organisasi teknologi yang rapuh menjadi mesin produk yang andal.",
     "overview": {
@@ -71,7 +71,7 @@
     }
   },
   "ctoaas_media": {
-    "title": "Meningkatkan Tim Engineering Media-Tech dari Feature Factory ke Pusat Inovasi",
+    "title": "Meningkatkan Tim Engineering Media-Tech dari Feature Factory ke Pusat Inovasi: CTO as a Service",
     "text": "Membantu platform media digital terkemuka beralih dari sekadar eksekusi ke inovasi strategis.",
     "desc": "Ketika pertumbuhan cepat melampaui kematangan engineering, tim ini butuh lebih dari sekadar fitur—mereka butuh transformasi. Kami restrukturisasi praktik agile mereka, otomatisasi DevOps, tetapkan KPI terukur, dan bantu mereka beralih dari eksekutor tugas ke pemilik produk sejati yang inovatif.",
     "overview": {

--- a/locales/id/main.json
+++ b/locales/id/main.json
@@ -42,13 +42,13 @@
     "heading": "Studi Kasus",
     "desc": "Temukan bagaimana kami berhasil mengubah tantangan menjadi peluang melalui solusi nyata yang mendorong dampak berkelanjutan dan pertumbuhan bisnis.",
     "button": "Baca Studi Kasus",
-    "0_title": "Mengubah Tim Teknologi Perikanan Menjadi Mesin Produk yang Skalabel: CTO as a Service",
+    "0_title": "Mengubah Tim Teknologi Perikanan Menjadi Mesin Produk yang Skalabel",
     "0_text": "Sebuah tim teknologi junior namun penuh semangat. Tidak ada produk yang sudah berjalan. Taruhannya besar. Kami terlibat secara mendalam dengan tim mereka untuk memperkenalkan struktur, membangun kepercayaan diri, dan merilis MVP yang berfungsi dalam 3 bulan. Melalui praktik agile yang ketat dan peluncuran sistem menyeluruh, kami membantu mengubah organisasi teknologi yang rapuh menjadi mesin produk yang andal.",
-    "0_category": "Studi Kasus",
+    "0_category": "CTO as a Service",
 
-    "1_title": "Meningkatkan Tim Rekayasa Media-Tech dari Pabrik Fitur Menjadi Pusat Inovasi: CTO as a Service",
+    "1_title": "Meningkatkan Tim Rekayasa Media-Tech dari Pabrik Fitur Menjadi Pusat Inovasi",
     "1_text": "Ketika pertumbuhan pesat melampaui kematangan rekayasa, tim ini membutuhkan lebih dari sekadar fitur—mereka membutuhkan transformasi. Kami merestrukturisasi praktik agile mereka, mengotomatisasi DevOps, menetapkan KPI yang terukur, dan membantu mereka beralih dari sekadar mengeksekusi tugas menjadi pemilik produk sejati yang mampu berinovasi.",
-    "1_category": "Studi Kasus"
+    "1_category": "CTO as a Service"
   },
   "project": {
     "heading": "Produk Open Source",

--- a/locales/id/main.json
+++ b/locales/id/main.json
@@ -42,11 +42,11 @@
     "heading": "Studi Kasus",
     "desc": "Temukan bagaimana kami berhasil mengubah tantangan menjadi peluang melalui solusi nyata yang mendorong dampak berkelanjutan dan pertumbuhan bisnis.",
     "button": "Baca Studi Kasus",
-    "0_title": "Mengubah Tim Teknologi Perikanan Menjadi Mesin Produk yang Skalabel",
+    "0_title": "Mengubah Tim Teknologi Perikanan Menjadi Mesin Produk yang Skalabel: CTO as a Service",
     "0_text": "Sebuah tim teknologi junior namun penuh semangat. Tidak ada produk yang sudah berjalan. Taruhannya besar. Kami terlibat secara mendalam dengan tim mereka untuk memperkenalkan struktur, membangun kepercayaan diri, dan merilis MVP yang berfungsi dalam 3 bulan. Melalui praktik agile yang ketat dan peluncuran sistem menyeluruh, kami membantu mengubah organisasi teknologi yang rapuh menjadi mesin produk yang andal.",
     "0_category": "Studi Kasus",
 
-    "1_title": "Meningkatkan Tim Rekayasa Media-Tech dari Pabrik Fitur Menjadi Pusat Inovasi",
+    "1_title": "Meningkatkan Tim Rekayasa Media-Tech dari Pabrik Fitur Menjadi Pusat Inovasi: CTO as a Service",
     "1_text": "Ketika pertumbuhan pesat melampaui kematangan rekayasa, tim ini membutuhkan lebih dari sekadar fitur—mereka membutuhkan transformasi. Kami merestrukturisasi praktik agile mereka, mengotomatisasi DevOps, menetapkan KPI yang terukur, dan membantu mereka beralih dari sekadar mengeksekusi tugas menjadi pemilik produk sejati yang mampu berinovasi.",
     "1_category": "Studi Kasus"
   },


### PR DESCRIPTION
Change the case studies label to match the relevant services
![2025-05-21_10-56](https://github.com/user-attachments/assets/92c9fcd8-c63d-46f6-a61b-409241183e39)
![2025-05-21_10-54](https://github.com/user-attachments/assets/6925d563-df19-492b-88a3-3fd030db54a7)

Fix the content alignment on the case study detail page:
![FireShot Capture 197 - Hyperjump Technology - localhost](https://github.com/user-attachments/assets/4dc9b151-5bc1-4f52-b989-6180691daa84)

