### PR TITLE
Fix: Fix hero subtitle cloud-native word break

### DIFF
--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -1,7 +1,7 @@
 {
   "hero": {
-    "heading": "Your Partner in Building Reliable, Modern Software",
-    "desc": "We help organizations deliver scalable, high-quality digital systems through engineering excellence and cloud-native technology."
+    "heading": "Your partner in building reliable, modern software",
+    "desc": "We help organizations deliver scalable, high\u2011quality digital systems through engineering excellence and cloud\u2011native technology."
   },
   "view_more": "View More",
   "see_more": "See More",

--- a/locales/id/main.json
+++ b/locales/id/main.json
@@ -1,7 +1,7 @@
 {
   "hero": {
-    "heading": "Mitra Anda dalam Membangun Perangkat Lunak yang Andal dan Modern",
-    "desc": "Kami membantu organisasi menghadirkan sistem digital yang skalabel dan berkualitas tinggi melalui keunggulan rekayasa dan teknologi cloud-native."
+    "heading": "Mitra anda dalam membangun perangkat lunak yang andal dan modern",
+    "desc": "Kami membantu organisasi menghadirkan sistem digital yang skalabel dan berkualitas tinggi melalui keunggulan rekayasa dan teknologi cloud\u2011native."
   },
   "view_more": "Lihat Selengkapnya",
   "see_more": "Lihat Selengkapnya",


### PR DESCRIPTION
11723: Fix hero subtitle "cloud-native" word break
11722: Use capitalization only for the first letter of each word in the hero title

![2025-06-02_11-37](https://github.com/user-attachments/assets/3e0bc747-44d4-4927-8192-78d2db5dc933)
![2025-06-02_11-34](https://github.com/user-attachments/assets/901f1922-2443-4260-b4df-1c11f477e881)
