### PR TITLE
Fix: Remove scroll placeholder if scroll is not needed in InferenceAI Agent

### DIFF
--- a/app/(inferenceai)/inferenceai/components/inference-ai-agent/index.tsx
+++ b/app/(inferenceai)/inferenceai/components/inference-ai-agent/index.tsx
@@ -268,7 +268,7 @@ export default function InferenceAIAgent() {
           </Button>
         </div>
         {/* Button */}
-        <div className="flex space-x-2 overflow-x-scroll whitespace-nowrap">
+        <div className="flex space-x-2 overflow-x-auto whitespace-nowrap">
           {DEFAULT_MESSAGES.map(({ text, id }) => (
             <Button
               key={id}


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/6011a9fd-f05a-42f4-a461-6c3497470d83)

After
![image](https://github.com/user-attachments/assets/9baf67cc-97ef-4a63-95cd-d7284cda2a64)
