### PR TITLE
Fix: Hidden predefined message in landing page chat UI

### DIFF
--- a/app/[lang]/components/landing-ai-agent.tsx
+++ b/app/[lang]/components/landing-ai-agent.tsx
@@ -234,6 +234,11 @@ export default function LandingAIAgent() {
               ...prevState,
               closed: false
             }));
+
+            // Scroll to bottom after 100ms to avoid the window opening and closing immediately
+            setTimeout(() => {
+              scrollToBottom();
+            }, 100);
           }}>
           <span className="hidden lg:block">Ask HyperBot</span>
           <span className="block lg:hidden">
@@ -559,6 +564,26 @@ export default function LandingAIAgent() {
                     height={10}
                   />
                 </Button>
+              </div>
+              {/* Default messages */}
+              <div
+                className={cn(
+                  "flex space-x-2 overflow-x-auto whitespace-nowrap",
+                  windowState.mode === "chat" && messages.length > 0 && "hidden"
+                )}>
+                {DEFAULT_MESSAGES.map(({ text, id }) => (
+                  <Button
+                    key={id}
+                    variant="outline"
+                    disabled={isSubmitting}
+                    className="rounded-md border border-white bg-transparent hover:cursor-pointer"
+                    onClick={() => {
+                      setText(text);
+                      inputRef.current?.focus();
+                    }}>
+                    {text}
+                  </Button>
+                ))}
               </div>
             </div>
           </div>


### PR DESCRIPTION
This PR removes the hidden default messages in Chat UI:

- Before
<img width="1601" height="721" alt="image" src="https://github.com/user-attachments/assets/6be218bb-80ed-4f5a-8056-15f66b3c6434" />

- After
<img width="1601" height="721" alt="image" src="https://github.com/user-attachments/assets/95d3b7e0-99a9-4086-b83d-6aac32f38baa" />

The default messages still available in Entrypoint UI:
<img width="1601" height="721" alt="image" src="https://github.com/user-attachments/assets/ca8b4fd7-c9fc-477f-b1ed-be2d597549c8" />



