### PR TITLE
Fix: Reduce gap between hero and content on service list page

### DIFF
--- a/app/[lang]/(hyperjump)/case-studies/page.tsx
+++ b/app/[lang]/(hyperjump)/case-studies/page.tsx
@@ -51,7 +51,7 @@ export default async function CaseStudiesPage({ params }: CaseStudyProps) {
   return (
     <main className="bg-white">
       <Hero lang={lang} />
-      <div className="xxl:max-w-7xl mx-auto flex w-full max-w-6xl flex-wrap items-center justify-center px-4 text-center md:px-20 md:py-12 xl:px-0">
+      <div className="xxl:max-w-7xl mx-auto flex w-full max-w-6xl flex-wrap items-center justify-center px-4 text-center md:px-20 md:py-8 xl:px-0">
         <h3 className="text-hyperjump-black w-72 text-[34px] font-medium md:w-full md:text-[40px]">
           {caseStudyExplore(lang)}
         </h3>
@@ -66,7 +66,7 @@ function Hero({ lang }: { lang: SupportedLanguage }) {
     <section
       id="hero"
       className="bg-services-hero text-hyperjump-black relative h-[415px] w-full px-4 text-center">
-      <div className="mx-auto flex h-full max-w-3xl flex-col items-center justify-center pt-16">
+      <div className="mx-auto flex h-full max-w-3xl flex-col items-center justify-center pt-12">
         <div
           className="text-hyperjump-black mb-4 text-3xl font-medium sm:text-4xl md:text-[40px]"
           dangerouslySetInnerHTML={{

--- a/app/[lang]/(hyperjump)/services/page.tsx
+++ b/app/[lang]/(hyperjump)/services/page.tsx
@@ -60,8 +60,8 @@ export default async function Services({ params }: ServicesProps) {
   return (
     <main className="bg-white">
       <Hero lang={lang} />
-      <div className="xxl:max-w-7xl mx-auto flex w-full max-w-6xl flex-wrap items-center justify-center px-4 py-8 text-center md:px-20 xl:px-0">
-        <h3 className="text-hyperjump-black mb-14 text-[34px] font-medium md:text-[40px]">
+      <div className="xxl:max-w-7xl mx-auto flex w-full max-w-6xl flex-wrap items-center justify-center px-4 pb-15 text-center md:px-20 xl:px-0">
+        <h3 className="text-hyperjump-black md:mb-14 mb-8 text-[28px] font-medium md:text-[40px]">
           {servicesHeading(lang)}
         </h3>
         <section className="space-y-16">
@@ -127,7 +127,7 @@ function Service({ lang, isReverseImagePosition = false, slug }: ServiceProps) {
           width={660}
           height={400}
         />
-        <div className="absolute -bottom-1 left-1 rounded-md">
+        <div className="absolute -bottom-1 right-1 rounded-md">
           <Image
             className="h-20 w-20"
             src={imageIconUrl}
@@ -185,10 +185,10 @@ function Hero({ lang }: { lang: SupportedLanguage }) {
       id="hero"
       className="bg-services-hero text-hyperjump-black relative h-[415px] w-full px-4 text-center">
       <div className="mx-auto flex h-full max-w-3xl flex-col items-center justify-center pt-16">
-        <h1 className="text-hyperjump-black mb-4 text-2xl font-medium sm:text-4xl md:text-[40px]">
+        <h1 className="text-hyperjump-black mb-4 font-medium text-4xl md:text-[40px]">
           {servicesHeroHeading(lang)}
         </h1>
-        <p className="text-hyperjump-gray text-base sm:text-lg">
+        <p className="text-hyperjump-gray text-lg">
           {servicesHeroDesc(lang)}
         </p>
       </div>

--- a/app/[lang]/(hyperjump)/services/page.tsx
+++ b/app/[lang]/(hyperjump)/services/page.tsx
@@ -60,7 +60,7 @@ export default async function Services({ params }: ServicesProps) {
   return (
     <main className="bg-white">
       <Hero lang={lang} />
-      <div className="xxl:max-w-7xl mx-auto flex w-full max-w-6xl flex-wrap items-center justify-center px-4 py-12 text-center md:px-20 xl:px-0">
+      <div className="xxl:max-w-7xl mx-auto flex w-full max-w-6xl flex-wrap items-center justify-center px-4 py-8 text-center md:px-20 xl:px-0">
         <h3 className="text-hyperjump-black mb-14 text-[34px] font-medium md:text-[40px]">
           {servicesHeading(lang)}
         </h3>
@@ -75,7 +75,7 @@ export default async function Services({ params }: ServicesProps) {
           ))}
         </section>
 
-        <section className="relative w-full pt-16">
+        <section className="relative w-full pt-8">
           <h3 className="text-hyperjump-black mb-4 text-[28px] font-medium md:text-4xl">
             {servicesPartnersHeading(lang)}
           </h3>

--- a/app/[lang]/(hyperjump)/services/page.tsx
+++ b/app/[lang]/(hyperjump)/services/page.tsx
@@ -61,7 +61,7 @@ export default async function Services({ params }: ServicesProps) {
     <main className="bg-white">
       <Hero lang={lang} />
       <div className="xxl:max-w-7xl mx-auto flex w-full max-w-6xl flex-wrap items-center justify-center px-4 pb-15 text-center md:px-20 xl:px-0">
-        <h3 className="text-hyperjump-black md:mb-14 mb-8 text-[28px] font-medium md:text-[40px]">
+        <h3 className="text-hyperjump-black mb-8 text-[28px] font-medium md:mb-14 md:text-[40px]">
           {servicesHeading(lang)}
         </h3>
         <section className="space-y-16">
@@ -127,7 +127,7 @@ function Service({ lang, isReverseImagePosition = false, slug }: ServiceProps) {
           width={660}
           height={400}
         />
-        <div className="absolute -bottom-1 right-1 rounded-md">
+        <div className="absolute right-1 -bottom-1 rounded-md">
           <Image
             className="h-20 w-20"
             src={imageIconUrl}
@@ -185,12 +185,10 @@ function Hero({ lang }: { lang: SupportedLanguage }) {
       id="hero"
       className="bg-services-hero text-hyperjump-black relative h-[415px] w-full px-4 text-center">
       <div className="mx-auto flex h-full max-w-3xl flex-col items-center justify-center pt-16">
-        <h1 className="text-hyperjump-black mb-4 font-medium text-4xl md:text-[40px]">
+        <h1 className="text-hyperjump-black mb-4 text-4xl font-medium md:text-[40px]">
           {servicesHeroHeading(lang)}
         </h1>
-        <p className="text-hyperjump-gray text-lg">
-          {servicesHeroDesc(lang)}
-        </p>
+        <p className="text-hyperjump-gray text-lg">{servicesHeroDesc(lang)}</p>
       </div>
     </section>
   );


### PR DESCRIPTION
<img width="1440" height="3671" alt="FireShot Capture 259 - Services - Engineering, Product, and Strategy - localhost" src="https://github.com/user-attachments/assets/f07872e9-0f06-4fff-b717-fb11877cbd38" />
![Uploading 2025-10-01_14-53.png…]()

