### PR TITLE
Fix: Hide our products section on the Inference AI service page

### DIFF
--- a/app/[lang]/(hyperjump)/data.ts
+++ b/app/[lang]/(hyperjump)/data.ts
@@ -502,20 +502,7 @@ export function services(lang: SupportedLanguage): Service[] {
             aiWhyUsReasons2(lang)
           ]
         },
-        ourProduct: [
-          {
-            slug: "startgpt",
-            title: "StartGPT",
-            description: startGptHeroDesc(lang),
-            basePath: "inferenceai"
-          },
-          {
-            slug: "media-pulse",
-            title: "MediaPulse",
-            description: mediaPulseHeroDesc(lang),
-            basePath: "inferenceai"
-          }
-        ]
+        ourProduct: []
       },
       description: aiDescription(lang),
       iconUrl: `/images/services/${ServiceSlug.InferenceAI}/icon.svg`,


### PR DESCRIPTION
<img width="1920" height="4099" alt="FireShot Capture 263 - Services - Inference AI - localhost" src="https://github.com/user-attachments/assets/716bf7fb-4fa9-4fc4-a8bc-aca5cec1c843" />
