### PR TITLE
ci: run e2e on direct main pushes only

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,14 +48,14 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.57.0-jammy
-      options: --ipc=host --user 1000
+      options: --ipc=host
     needs: [direct_push_check]
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.direct_push_check.outputs.is_direct == 'true')
     env:
       # Playwright's Firefox won't launch in the container unless $HOME is owned by the current user.
-      HOME: /home/pwuser
+      HOME: /root
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,13 +7,44 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: e2e-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  direct_push_check:
+    name: Detect direct push to main
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    outputs:
+      is_direct: ${{ steps.detect.outputs.is_direct }}
+    steps:
+      - name: Determine if commit belongs to a PR
+        id: detect
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const sha = context.sha
+            // If this commit is associated with any PR, it's almost certainly coming from a PR merge.
+            // Direct pushes to main won't have associated PRs.
+            const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: sha,
+            })
+
+            core.setOutput('is_direct', String(data.length === 0))
+
   e2e:
     runs-on: ubuntu-latest
+    needs: [direct_push_check]
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.direct_push_check.outputs.is_direct == 'true')
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -94,7 +125,7 @@ jobs:
     name: Merge Playwright report
     runs-on: ubuntu-latest
     if: always()
-    needs: [e2e]
+    needs: [direct_push_check, e2e]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.57.0-jammy
-      options: --ipc=host --user 1001
+      options: --ipc=host --user 1000
     needs: [direct_push_check]
     if: |
       github.event_name == 'pull_request' ||

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,6 +46,9 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-jammy
+      options: --ipc=host
     needs: [direct_push_check]
     if: |
       github.event_name == 'pull_request' ||
@@ -97,17 +100,6 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          # Cache per-browser to avoid cross-job races and partial caches
-          # when matrix runs in parallel.
-          key: ${{ runner.os }}-playwright-${{ matrix.browser }}-${{ hashFiles('bun.lock') }}
-
-      - name: Install Playwright browsers
-        run: bunx playwright install ${{ matrix.browser }} --with-deps
 
       - name: Build app
         run: bun run build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,6 @@ jobs:
   direct_push_check:
     name: Detect direct push to main
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     outputs:
       is_direct: ${{ steps.detect.outputs.is_direct }}
     steps:
@@ -28,6 +27,12 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            if (context.eventName !== 'push' || context.ref !== 'refs/heads/main') {
+              // Only `push` to `main` needs direct-vs-merge detection.
+              core.setOutput('is_direct', 'false')
+              return
+            }
+
             const sha = context.sha
             // If this commit is associated with any PR, it's almost certainly coming from a PR merge.
             // Direct pushes to main won't have associated PRs.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,6 +53,9 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.direct_push_check.outputs.is_direct == 'true')
+    env:
+      # Playwright's Firefox won't launch in the container unless $HOME is owned by the current user.
+      HOME: /root
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Install unzip
+        run: apt-get update && apt-get install -y unzip
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -126,6 +129,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Install unzip
+        run: sudo apt-get update && sudo apt-get install -y unzip
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,14 +48,14 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.57.0-jammy
-      options: --ipc=host
+      options: --ipc=host --user 1001
     needs: [direct_push_check]
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.direct_push_check.outputs.is_direct == 'true')
     env:
       # Playwright's Firefox won't launch in the container unless $HOME is owned by the current user.
-      HOME: /root
+      HOME: /home/pwuser
     timeout-minutes: 45
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Keep E2E as a PR check.
- Skip redundant post-merge E2E runs on `main` by only running on `main` when the pushed commit is not associated with any PR.

## Notes
- Uses GitHub API to detect PR-associated commits on `push` to `main`.

## Test plan
- [ ] Open a PR and confirm E2E runs.
- [ ] Merge that PR and confirm E2E does not rerun on `main`.
- [ ] Push directly to `main` (admin-only) and confirm E2E runs.