### PR TITLE
Fix E2E report job failing when E2E is skipped

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -127,7 +127,8 @@ jobs:
   e2e_report:
     name: Merge Playwright report
     runs-on: ubuntu-latest
-    if: always()
+    # Skip when `e2e` did not run (e.g. merge push to main); merge-reports fails with no blob artifacts.
+    if: ${{ !cancelled() && (needs.e2e.result == 'success' || needs.e2e.result == 'failure') }}
     needs: [direct_push_check, e2e]
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

The merge Playwright report job ran whenever the workflow finished, including when the `e2e` matrix was skipped (for example after a merge push to `main`). With no blob artifacts, `playwright merge-reports` exited with code 1 and failed the workflow.

The merge job now runs only when `e2e` actually completed with success or failure, so skipped `e2e` runs no longer break CI.

## Important changes

- Gate `e2e_report` on `needs.e2e.result` being `success` or `failure`, and skip when the workflow run was cancelled.

## Other changes

- Added a short comment in the workflow explaining why the condition exists.

## Key files to review

- `.github/workflows/e2e.yml` — `e2e_report` `if:` condition.

## How to test

1. Open the Actions tab on this PR and confirm all workflow jobs succeed.
2. After merge, push a merge commit to `main` (non-direct) and confirm the E2E workflow completes green while `e2e` is skipped.
